### PR TITLE
Fix fall event on reset

### DIFF
--- a/src/Plugin.cs
+++ b/src/Plugin.cs
@@ -132,6 +132,7 @@ namespace FastReset {
 
         private CameraLook camY;
         private Climbing climbing;
+        private FallingEvent fallingEvent;
         private IceAxe iceAxes;
         private Rigidbody playerRB;
         private RopeAnchor ropeAnchor;
@@ -157,6 +158,7 @@ namespace FastReset {
             camY = null;
             iceAxes = null;
             climbing = null;
+            fallingEvent = null;
             playerRB = null;
             ropeAnchor = null;
             playerTransform = null;
@@ -198,6 +200,7 @@ namespace FastReset {
             flag = flags[0];
 
             camY = GameObject.Find("CamY").GetComponent<CameraLook>();
+            fallingEvent = GameObject.FindObjectOfType<FallingEvent>();
             iceAxes = GetField<IceAxe>(flag, "iceAxes");
             climbing = GetField<Climbing>(flag, "climbing");
             playerRB = GetField<Rigidbody>(flag, "playerRB");
@@ -265,6 +268,7 @@ namespace FastReset {
 
             // Make sure things needed for teleporting exist
             return climbing != null
+                && fallingEvent != null
                 && iceAxes != null
                 && playerRB != null
                 && playerTransform != null;
@@ -288,6 +292,10 @@ namespace FastReset {
             iceAxes.ReleaseRight(false);
 
             playerRB.velocity = Vector3.zero;
+
+            fallingEvent.fellShortDistance = false;
+            fallingEvent.fellLongDistance = false;
+            fallingEvent.fellToDeath = false;
 
             if (isSolemnTempest == true) {
                 playerTransform.position = leavePeakScene.transform.position + data.position;


### PR DESCRIPTION
Resets the following flags that get toggled by the FallingEvent's update script to prevent a fall reset on teleport.

- FallingEvent.fellShortDistance
- FallingEvent.fellLongDistance
- FallingEvent.fellToDeath